### PR TITLE
Make slash on OAuth endpoints optional to handle clients that cannot …

### DIFF
--- a/takahe/urls.py
+++ b/takahe/urls.py
@@ -344,9 +344,9 @@ urlpatterns = [
     path("inbox/", activitypub.Inbox.as_view(), name="shared_inbox"),
     # API/Oauth
     path("api/", include("api.urls")),
-    path("oauth/authorize", oauth.AuthorizationView.as_view()),
-    path("oauth/token", oauth.TokenView.as_view()),
-    path("oauth/revoke", oauth.RevokeTokenView.as_view()),
+    re_path(r"oauth/authorize/?$", oauth.AuthorizationView.as_view()),
+    re_path(r"oauth/token/?$", oauth.TokenView.as_view()),
+    re_path(r"oauth/revoke/?$", oauth.RevokeTokenView.as_view()),
     # Stator
     path(".stator/", stator.RequestRunner.as_view()),
     # Django admin


### PR DESCRIPTION
…follow redirects. (#670)