### PR TITLE
workaround pydantic 2 limitation

### DIFF
--- a/takahe/settings.py
+++ b/takahe/settings.py
@@ -476,7 +476,7 @@ if SETUP.MEDIA_BACKEND:
         raise ValueError(f"Unsupported media backend {SETUP.MEDIA_BACKEND.scheme}")
 
 CACHES = {
-    "default": django_cache_url.parse(SETUP.CACHES_DEFAULT or "dummy://"),
+    "default": django_cache_url.parse(str(SETUP.CACHES_DEFAULT or "dummy://")),
 }
 
 if SETUP.ERROR_EMAILS:


### PR DESCRIPTION
fix `AttributeError: 'pydantic_core._pydantic_core.Url' object has no attribute 'decode'` when setting `TAKAHE_CACHES_DEFAULT`

The root cause is, as mentioned [here](https://github.com/pydantic/pydantic/issues/7186#issuecomment-1691594032), urls inherit from str in pydantic v1, but no longer in v2.