### PR TITLE
improve compatibility with Mastodon apps

### DIFF
--- a/api/urls.py
+++ b/api/urls.py
@@ -148,6 +148,7 @@ urlpatterns = [
     # Statuses
     path("v1/statuses", statuses.post_status),
     path("v1/statuses/<id>/context", statuses.status_context),
+    path("v1/statuses/<id>/history", statuses.status_history),
     path("v1/statuses/<id>/favourite", statuses.favourite_status),
     path("v1/statuses/<id>/unfavourite", statuses.unfavourite_status),
     path("v1/statuses/<id>/favourited_by", statuses.favourited_by),
@@ -180,6 +181,7 @@ urlpatterns = [
     path("v1/conversations", timelines.conversations),
     path("v1/favourites", timelines.favourites),
     # Trends
+    path("v1/trends", trends.trends_tags),  # legacy trending API
     path("v1/trends/tags", trends.trends_tags),
     path("v1/trends/statuses", trends.trends_statuses),
     path("v1/trends/links", trends.trends_links),

--- a/api/views/statuses.py
+++ b/api/views/statuses.py
@@ -191,6 +191,13 @@ def status_context(request, id: str) -> schemas.Context:
     )
 
 
+@scope_required("read:statuses")
+@api_view.get
+def status_history(request, id: str) -> list:
+    # not implemented yet
+    return []
+
+
 @scope_required("write:favourites")
 @api_view.post
 def favourite_status(request, id: str) -> schemas.Status:


### PR DESCRIPTION
- `v1/trends`: it's same as `v1/trends/tags` but in old version of API doc and implemented by a few Mastodon compatible apps
- `v1/statuses/<id>/history`: return `[]` instead of 404, otherwise Mastodon official app will stuck at loading status 