### PR TITLE
cache public trends

### DIFF
--- a/api/views/trends.py
+++ b/api/views/trends.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 
+from django.core.cache import cache
 from django.db.models import Count
 from django.http import HttpRequest
 from django.utils import timezone
@@ -15,12 +16,14 @@ from hatchway import api_view
 def trends_tags(
     request: HttpRequest,
     limit: int = 10,
-    offset: int | None = None,
+    offset: int = 0,
 ) -> list[schemas.Tag]:
-    if limit > 40:
-        limit = 40
+    popular_tags = cache.get("trends_tags", None)
+    if popular_tags is None:
+        popular_tags = Hashtag.popular(limit=100, offset=0)
+        cache.set("trends_tags", popular_tags, 3600)
     return schemas.Tag.map_from_hashtags(
-        Hashtag.popular(limit=limit, offset=offset),
+        popular_tags[offset : offset + limit],
         domain=request.domain,
         identity=request.identity,
     )
@@ -31,19 +34,26 @@ def trends_tags(
 def trends_statuses(
     request: HttpRequest,
     limit: int = 10,
-    offset: int | None = None,
+    offset: int = 0,
 ) -> list[schemas.Status]:
-    if limit > 40:
-        limit = 40
-    if offset is None:
-        offset = 0
-    since = timezone.now().date() - timedelta(days=7)
+    popular_post_ids = cache.get("trends_statuses", None)
+    if popular_post_ids is None:
+        since = timezone.now().date() - timedelta(days=7)
+        popular_post_ids = list(
+            Post.objects.not_hidden()
+            .public()
+            .filter(author__discoverable=True)
+            .filter(published__gte=since)
+            .annotate(num_interactions=Count("interactions"))
+            .filter(num_interactions__gte=1)
+            .order_by("-num_interactions", "-published")
+            .values_list("id", flat=True)[:100]
+        )
+        cache.set("trends_statuses", popular_post_ids, 3600)
     posts = (
         Post.objects.not_hidden()
-        .visible_to(request.identity)
-        .filter(published__gte=since)
-        .annotate(num_interactions=Count("interactions"))
-        .order_by("-num_interactions", "-published")[offset : offset + limit]
+        .filter(id__in=popular_post_ids[offset : offset + limit])
+        .order_by("-published")
     )
     return schemas.Status.map_from_post(list(posts), request.identity)
 

--- a/core/models/config.py
+++ b/core/models/config.py
@@ -248,6 +248,7 @@ class Config(models.Model):
         cache_timeout_page_timeline: int = 60 * 3
         cache_timeout_page_post: int = 60 * 2
         cache_timeout_identity_feed: int = 60 * 5
+        cache_timeout_trends: int = 60 * 60
 
         restricted_usernames: str = "\n".join(
             [


### PR DESCRIPTION
 - cache status and tag trends for 1 hour
 - for trending statuses, only show public statuses whose authors choose not to opt out discovery.