### PR TITLE
fix fediverse:creator

### DIFF
--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -658,6 +658,7 @@ class Identity(StatorModel):
             "url": self.absolute_profile_uri(),
             "toot:discoverable": self.discoverable,
             "toot:indexable": self.indexable,
+            "attributionDomains": [self.domain_id],
         }
         if self.name:
             response["name"] = self.name


### PR DESCRIPTION
the current implementation would not work without attributionDomains pointing back, this pr fix that.