### PR TITLE
Support JSON parameters for set markers method

### DIFF
--- a/api/views/markers.py
+++ b/api/views/markers.py
@@ -11,9 +11,11 @@ class MarkerSchema(Schema):
 
     last_read_id: str
 
+
 class PostMarkersSchema(Schema):
-    home: MarkerSchema | None = None;
-    notifications: MarkerSchema | None = None;
+    home: MarkerSchema | None = None
+    notifications: MarkerSchema | None = None
+
 
 @scope_required("read:statuses")
 @api_view.get
@@ -29,12 +31,13 @@ def markers(request: HttpRequest) -> dict[str, schemas.Marker]:
 
 @scope_required("write:statuses")
 @api_view.post
-def set_markers(request: HttpRequest, details: PostMarkersSchema) -> dict[str, schemas.Marker]:
+def set_markers(
+    request: HttpRequest, details: PostMarkersSchema
+) -> dict[str, schemas.Marker]:
     markers = {}
     for timeline, defaults in details.model_dump(exclude_none=True).items():
         marker, created = request.identity.markers.get_or_create(
-            timeline=timeline,
-            defaults=defaults
+            timeline=timeline, defaults=defaults
         )
         if not created:
             marker.last_read_id = defaults["last_read_id"]

--- a/api/views/markers.py
+++ b/api/views/markers.py
@@ -2,8 +2,18 @@ from django.http import HttpRequest
 
 from api import schemas
 from api.decorators import scope_required
-from hatchway import api_view
+from pydantic import ConfigDict
+from hatchway import Schema, api_view
 
+
+class MarkerSchema(Schema):
+    model_config = ConfigDict(coerce_numbers_to_str=True)
+
+    last_read_id: str
+
+class PostMarkersSchema(Schema):
+    home: MarkerSchema | None = None;
+    notifications: MarkerSchema | None = None;
 
 @scope_required("read:statuses")
 @api_view.get
@@ -19,20 +29,15 @@ def markers(request: HttpRequest) -> dict[str, schemas.Marker]:
 
 @scope_required("write:statuses")
 @api_view.post
-def set_markers(request: HttpRequest) -> dict[str, schemas.Marker]:
+def set_markers(request: HttpRequest, details: PostMarkersSchema) -> dict[str, schemas.Marker]:
     markers = {}
-    for key, last_id in request.PARAMS.items():
-        if not key.endswith("[last_read_id]"):
-            continue
-        timeline = key.replace("[last_read_id]", "")
+    for timeline, defaults in details.model_dump(exclude_none=True).items():
         marker, created = request.identity.markers.get_or_create(
             timeline=timeline,
-            defaults={
-                "last_read_id": last_id,
-            },
+            defaults=defaults
         )
         if not created:
-            marker.last_read_id = last_id
+            marker.last_read_id = defaults["last_read_id"]
             marker.save()
         markers[timeline] = schemas.Marker.from_marker(marker)
     return markers


### PR DESCRIPTION
The [masto.js](https://github.com/neet/masto.js/) client library passes parameters to the set marker API as JSON, but this is not supported by the current implementation in Takahe.

This change enables JSON parameters for this specific API.

The main documentation for the Mastodon API just talks about parameters as form data, but in the [Getting started with the API](https://docs.joinmastodon.org/client/intro/#parameters) it mentions that query strings, form data, and JSON should all be supported. So I think Takahe should support JSON here as well.