### PR TITLE
improve blocking behaviour

### DIFF
--- a/api/views/accounts.py
+++ b/api/views/accounts.py
@@ -191,7 +191,9 @@ def account_statuses(
     )
     queryset = (
         identity.posts.not_hidden()
-        .unlisted(include_replies=not exclude_replies)
+        .visible_to(
+            request.identity, include_replies=not exclude_replies, include_muted=True
+        )
         .select_related("author", "author__domain")
         .prefetch_related(
             "attachments",

--- a/api/views/polls.py
+++ b/api/views/polls.py
@@ -1,7 +1,9 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from hatchway import api_view, QueryOrBody
 
 from activities.models import Post, PostInteraction
+from users.models import Block
 from api import schemas
 from api.decorators import scope_required
 
@@ -10,6 +12,10 @@ from api.decorators import scope_required
 @api_view.get
 def get_poll(request, id: str) -> schemas.Poll:
     post = get_object_or_404(Post, pk=id, type=Post.Types.question)
+    if Block.maybe_get(
+        source=post.author, target=request.identity, require_active=True
+    ):
+        raise Http404
     return schemas.Poll.from_post(post, identity=request.identity)
 
 

--- a/api/views/statuses.py
+++ b/api/views/statuses.py
@@ -73,7 +73,7 @@ def post_for_id(request: HttpRequest, id: str) -> Post:
     """
     if request.identity:
         queryset = Post.objects.not_hidden().visible_to(
-            request.identity, include_replies=True
+            request.identity, include_replies=True, include_muted=True
         )
     else:
         queryset = Post.objects.not_hidden().unlisted()

--- a/api/views/trends.py
+++ b/api/views/trends.py
@@ -56,6 +56,7 @@ def trends_statuses(
     posts = (
         Post.objects.not_hidden()
         .filter(id__in=popular_post_ids[offset : offset + limit])
+        .visible_to(request.identity)
         .order_by("-published")
     )
     return schemas.Status.map_from_post(list(posts), request.identity)


### PR DESCRIPTION
Currently there are a few loopholes about block, a blocked user may still see/interact with posts they should not be able to, this PR hopefully fixes most if not all of them.

Updated area:
 - Public/Trend/List timelines
 - PostInteraction - handled in state handler
 - a few other places that already uses `PostQuerySet.visible_to`
 - when blocking, also clean up bookmark, interactions and mentions