### PR TITLE
add report api

### DIFF
--- a/api/schemas.py
+++ b/api/schemas.py
@@ -554,3 +554,16 @@ class Marker(Schema):
         marker: users_models.Marker,
     ) -> "Marker":
         return cls(**marker.to_mastodon_json())
+
+
+class Report(Schema):
+    id: str
+    action_taken: bool = False
+    action_taken_at: str | None = None
+    category: str = "other"
+    comment: str
+    forwarded: bool = False
+    created_at: str
+    status_ids: list[int]
+    rule_ids: list[int] | None = None
+    target_account: Account

--- a/api/urls.py
+++ b/api/urls.py
@@ -17,6 +17,7 @@ from api.views import (
     polls,
     preferences,
     push,
+    report,
     search,
     statuses,
     suggestions,
@@ -187,4 +188,5 @@ urlpatterns = [
     path("v1/trends/links", trends.trends_links),
     # Suggestions
     path("v2/suggestions", suggestions.suggested_users),
+    path("v1/reports", report.file_report),
 ]

--- a/api/views/report.py
+++ b/api/views/report.py
@@ -1,0 +1,36 @@
+from django.shortcuts import get_object_or_404
+
+from activities.models import Post
+from api import schemas
+from api.decorators import scope_required
+from hatchway import ApiError, api_view, QueryOrBody
+from users.models import Identity, Report
+
+
+@scope_required("write:reports")
+@api_view.post
+def file_report(
+    request,
+    account_id: QueryOrBody[str],
+    status_ids: QueryOrBody[list[str]] = [],
+    comment: QueryOrBody[str] = "",
+    forward: QueryOrBody[bool] = False,
+    category: QueryOrBody[str] = "other",
+    **kwargs,
+) -> schemas.Report:
+    subject_identity = get_object_or_404(Identity, pk=account_id)
+    if not status_ids:
+        raise ApiError(422, "Not status ids provided")
+    subject_post = Post.objects.filter(id__in=status_ids).first()
+    if not subject_post:
+        raise ApiError(422, "Not status matched")
+    r = Report.objects.create(
+        subject_identity=subject_identity,
+        subject_post=subject_post,
+        source_domain=request.identity.domain,
+        source_identity=request.identity,
+        type=category,
+        complaint=comment or category or "",
+        forward=forward,
+    )
+    return r.to_mastodon_json()

--- a/users/migrations/0005_report.py
+++ b/users/migrations/0005_report.py
@@ -42,13 +42,7 @@ class Migration(migrations.Migration):
                 (
                     "type",
                     models.CharField(
-                        choices=[
-                            ("spam", "Spam"),
-                            ("hateful", "Hateful"),
-                            ("illegal", "Illegal"),
-                            ("remote", "Remote"),
-                            ("other", "Other"),
-                        ],
+                        default="other",
                         max_length=100,
                     ),
                 ),


### PR DESCRIPTION
added Mastodon-compatible api to file report
removed `Report.Type` as the previous enum values in code is inconsistent with the one in [Mastodon API doc](https://docs.joinmastodon.org/methods/reports/), and there seems no need to limit it anyway. 
There is a gap that one report (both via API or AP) may contain more than one status but we only store one, but we can improve that in future I suppose.