### PR TITLE
support group actor

### DIFF
--- a/templates/admin/identities.html
+++ b/templates/admin/identities.html
@@ -35,6 +35,7 @@
                 <td class="name">
                     <a href="{{ identity.urls.admin_edit }}?page={{ page_obj.number }}" class="overlay"></a>
                     {{ identity.html_name_or_handle }}
+                    {% if identity.actor_type != 'person' %}<small>{{ identity.actor_type }}</small>{% endif %}
                     <small>@{{ identity.handle }}</small>
                 </td>
                 <td>

--- a/templates/admin/identity_edit.html
+++ b/templates/admin/identity_edit.html
@@ -67,6 +67,11 @@
                     {% endfor %}
                 </p>
             </fieldset>
+            <fieldset>
+                <legend>Actor Type</legend>
+                <p>{% include "forms/_field.html" with field=form.actor_type %}</p>
+                <p class="help">Type "group" has special behavior: automatically boost posts from followed users.</p>
+            </fieldset>
         {% endif %}
         <fieldset>
             <legend>Technical</legend>
@@ -117,7 +122,7 @@
         <div class="buttons">
             <a href="{{ identity.urls.admin }}?page={{ page }}" class="button secondary left">Back</a>
             <a href="{{ identity.urls.view }}" class="button secondary">View Profile</a>
-            <button>Save Notes</button>
+            <button>Save</button>
         </div>
     </form>
 {% endblock %}

--- a/templates/identity/view.html
+++ b/templates/identity/view.html
@@ -48,6 +48,7 @@
         </div>
 
         <h1>{{ identity.html_name_or_handle }}</h1>
+        {% if identity.actor_type != 'person' %}<small>{{ identity.actor_type }}</small>{% endif %}
         <small>
             @{{ identity.handle }}
             <a title="Copy handle"

--- a/tests/activities/models/test_group_actor.py
+++ b/tests/activities/models/test_group_actor.py
@@ -1,0 +1,293 @@
+import pytest
+from django.utils import timezone
+
+from activities.models import (
+    FanOut,
+    Post,
+    PostInteraction,
+    PostInteractionStates,
+    TimelineEvent,
+)
+from activities.models.fan_out import FanOutStates
+from users.models import Follow, FollowStates
+
+
+@pytest.fixture
+def group_identity(identity_factory):
+    """Create a local group identity"""
+    identity = identity_factory(username="group_test", actor_type="group")
+    return identity
+
+
+@pytest.mark.django_db
+def test_group_identity_property(identity, group_identity):
+    """Test the is_group property"""
+    assert not identity.is_group
+    assert group_identity.is_group
+
+
+@pytest.mark.django_db
+def test_group_actor_auto_boost_post_from_followed_user(
+    identity, remote_identity, group_identity, config_system
+):
+    """Test that group actor automatically boosts posts from users it follows"""
+    # Create a follow relationship from group to another user
+    follow = Follow.objects.create(
+        source=group_identity,
+        target=identity,
+    )
+    follow.transition_perform(FollowStates.accepted)
+
+    # Create a post by the followed user
+    post = Post.create_local(
+        author=identity,
+        content="<p>Test post from followed user</p>",
+    )
+
+    # Create a fanout to the group
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.post,
+        subject_post=post,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Check that the group boosted the post
+    boost = PostInteraction.objects.filter(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state__in=PostInteractionStates.group_active(),
+    )
+
+    assert boost.exists()
+
+
+@pytest.mark.django_db
+def test_group_actor_auto_boost_post_with_mention(
+    identity, remote_identity, group_identity, config_system
+):
+    """Test that group actor automatically boosts posts that mention it"""
+    # Create a post that mentions the group
+    post = Post.create_local(
+        author=identity,
+        content=f'<p>Test post mentioning <span class="h-card"><a href="https://example.com/@{group_identity.username}@example.com">@{group_identity.username}</a></span></p>',
+    )
+
+    # Add the mention
+    post.mentions.add(group_identity)
+
+    # Create a fanout to the group
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.post,
+        subject_post=post,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Check that the group boosted the post
+    boost = PostInteraction.objects.filter(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state__in=PostInteractionStates.group_active(),
+    )
+
+    assert boost.exists()
+
+
+@pytest.mark.django_db
+def test_group_actor_no_auto_boost_own_post(group_identity, config_system):
+    """Test that group actor doesn't boost its own posts"""
+    # Create a post by the group itself
+    post = Post.create_local(
+        author=group_identity,
+        content="<p>Test post from the group</p>",
+    )
+
+    # Create a fanout to the group
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.post,
+        subject_post=post,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Check that the group did not boost its own post
+    boost = PostInteraction.objects.filter(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+    )
+
+    assert not boost.exists()
+
+
+@pytest.mark.django_db
+def test_group_actor_unboost_on_post_deletion(identity, group_identity, config_system):
+    """Test that group actor removes boost when a post is deleted"""
+    # Create a post and a boost by the group
+    post = Post.create_local(
+        author=identity,
+        content="<p>Test post to be deleted</p>",
+    )
+
+    # Create boost manually
+    boost = PostInteraction.objects.create(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        published=timezone.now(),
+    )
+    boost.transition_perform(PostInteractionStates.new)
+    boost.transition_perform(PostInteractionStates.fanned_out)
+
+    # Verify the boost exists and is active
+    assert PostInteraction.objects.filter(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state__in=PostInteractionStates.group_active(),
+    ).exists()
+
+    # Create a post deletion fanout
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.post_deleted,
+        subject_post=post,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Verify the boost is now undone
+    boost.refresh_from_db()
+    assert boost.state == PostInteractionStates.undone
+
+
+@pytest.mark.django_db
+def test_group_actor_boost_from_timeline_boost(
+    identity, remote_identity, group_identity, config_system
+):
+    """Test that group actor automatically boosts when it receives a boost in its timeline"""
+    # Create a post by remote identity
+    post = Post.create_local(
+        author=remote_identity,
+        content="<p>Test post to be boosted</p>",
+    )
+
+    # Create a boost by identity
+    boost = PostInteraction.objects.create(
+        identity=identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        published=timezone.now(),
+    )
+    boost.transition_perform(PostInteractionStates.new)
+    boost.transition_perform(PostInteractionStates.fanned_out)
+
+    # Create a fanout for the boost to the group
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.interaction,
+        subject_post=post,
+        subject_post_interaction=boost,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Check that the group also boosted the post
+    group_boost = PostInteraction.objects.filter(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state__in=PostInteractionStates.group_active(),
+    )
+
+    assert group_boost.exists()
+
+
+@pytest.mark.django_db
+def test_group_actor_unboost_with_timeline_check(
+    identity, group_identity, config_system
+):
+    """Test that group actor checks timeline before unboosting a post"""
+    # Create a post
+    post = Post.create_local(
+        author=identity,
+        content="<p>Test post with timeline check</p>",
+    )
+
+    # Create boost manually
+    boost = PostInteraction.objects.create(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        published=timezone.now(),
+    )
+    boost.transition_perform(PostInteractionStates.new)
+    boost.transition_perform(PostInteractionStates.fanned_out)
+
+    # Create a timeline event for this post (as if group was mentioned or follows author)
+    TimelineEvent.objects.create(
+        identity=group_identity,
+        type=TimelineEvent.Types.post,
+        subject_post=post,
+    )
+
+    # Create an unboost fanout
+    interaction_undo = PostInteraction.objects.create(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state=PostInteractionStates.undone,
+    )
+
+    fanout = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.undo_interaction,
+        subject_post=post,
+        subject_post_interaction=interaction_undo,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout)
+
+    # Verify the boost is still active since post is in timeline
+    boost.refresh_from_db()
+    assert boost.state == PostInteractionStates.fanned_out
+
+    # Now remove the timeline event and try again
+    TimelineEvent.objects.filter(
+        identity=group_identity,
+        subject_post=post,
+    ).delete()
+
+    # Create a new unboost fanout
+    interaction_undo2 = PostInteraction.objects.create(
+        identity=group_identity,
+        post=post,
+        type=PostInteraction.Types.boost,
+        state=PostInteractionStates.undone,
+    )
+
+    fanout2 = FanOut.objects.create(
+        identity=group_identity,
+        type=FanOut.Types.undo_interaction,
+        subject_post=post,
+        subject_post_interaction=interaction_undo2,
+    )
+
+    # Process the fanout
+    FanOutStates.handle_new(fanout2)
+
+    # Verify the boost is now undone since post is not in timeline
+    boost.refresh_from_db()
+    assert boost.state == PostInteractionStates.undone

--- a/users/models/identity.py
+++ b/users/models/identity.py
@@ -82,6 +82,7 @@ class IdentityStates(StateGraph):
     @classmethod
     def targets_fan_out(cls, identity: "Identity", type_: str) -> None:
         from activities.models import FanOut
+
         from users.models import Follow
 
         # Fan out to each target
@@ -133,6 +134,7 @@ class IdentityStates(StateGraph):
             PostStates,
             TimelineEvent,
         )
+
         from users.models import (
             Bookmark,
             Follow,
@@ -607,6 +609,10 @@ class Identity(StatorModel):
     @property
     def limited(self) -> bool:
         return self.restriction == self.Restriction.limited
+
+    @property
+    def is_group(self) -> bool:
+        return self.actor_type == "group"
 
     ### ActivityPub (outbound) ###
 

--- a/users/views/admin/identities.py
+++ b/users/views/admin/identities.py
@@ -57,6 +57,10 @@ class IdentityEdit(FormView):
 
     class form_class(forms.Form):
         notes = forms.CharField(widget=forms.Textarea, required=False)
+        actor_type = forms.ChoiceField(
+            choices=[(t, t) for t in Identity.ACTOR_TYPES],
+            required=False,
+        )
 
     def dispatch(self, request, id, *args, **kwargs):
         self.identity = get_object_or_404(Identity, id=id)
@@ -78,10 +82,15 @@ class IdentityEdit(FormView):
         return super().post(request, *args, **kwargs)
 
     def get_initial(self):
-        return {"notes": self.identity.admin_notes}
+        return {
+            "notes": self.identity.admin_notes,
+            "actor_type": self.identity.actor_type,
+        }
 
     def form_valid(self, form):
         self.identity.admin_notes = form.cleaned_data["notes"]
+        if self.identity.local and form.cleaned_data["actor_type"]:
+            self.identity.actor_type = form.cleaned_data["actor_type"]
         self.identity.save()
         return redirect(".")
 
@@ -89,4 +98,5 @@ class IdentityEdit(FormView):
         context = super().get_context_data(**kwargs)
         context["identity"] = self.identity
         context["page"] = self.request.GET.get("page")
+        context["actor_types"] = Identity.ACTOR_TYPES
         return context


### PR DESCRIPTION
 - admin can change identity's actor type 
 - if a local identity's actor type is `group`, it will automatically boost everything coming to its timeline ( mentioned it, post from an author it follows, boost from an author it follows ), so its followers will receive those posts