### PR TITLE
return follower collection with count

### DIFF
--- a/users/views/identity.py
+++ b/users/views/identity.py
@@ -239,7 +239,7 @@ class IdentityFollows(ListView):
                 {
                     "type": "OrderedCollection",
                     "totalItems": self.get_queryset().count(),
-                    "orderedItems": [],
+                    # "orderedItems": [],
                 }
             ),
             content_type="application/activity+json",


### PR DESCRIPTION
we already fetch follower count from other instances, so this only makes sense for us to serve it too. 