### PR TITLE
load nodeinfo 2.x instead of 2.0 only

### DIFF
--- a/users/models/domain.py
+++ b/users/models/domain.py
@@ -213,9 +213,8 @@ class Domain(StatorModel):
             else:
                 try:
                     for link in response.json().get("links", []):
-                        if (
-                            link.get("rel")
-                            == "http://nodeinfo.diaspora.software/ns/schema/2.0"
+                        if "://nodeinfo.diaspora.software/ns/schema/2." in link.get(
+                            "rel"
                         ):
                             nodeinfo20_url = link.get("href", nodeinfo20_url)
                             break


### PR DESCRIPTION
some servers only has nodeinfo 2.1, which is similar to 2.0 anyway.