### PR TITLE
use current user identity when fetch remote post

### DIFF
--- a/activities/models/post.py
+++ b/activities/models/post.py
@@ -1072,7 +1072,7 @@ class Post(StatorModel):
         return post
 
     @classmethod
-    def by_object_uri(cls, object_uri, fetch=False) -> "Post":
+    def by_object_uri(cls, object_uri, fetch=False, fetch_as=None) -> "Post":
         """
         Gets the post by URI - either looking up locally, or fetching
         from the other end if it's not here.
@@ -1082,7 +1082,7 @@ class Post(StatorModel):
         except cls.DoesNotExist:
             if fetch:
                 try:
-                    response = SystemActor().signed_request(
+                    response = (fetch_as or SystemActor()).signed_request(
                         method="get", uri=object_uri
                     )
                 except (httpx.HTTPError, ssl.SSLCertVerificationError, ValueError):

--- a/activities/services/search.py
+++ b/activities/services/search.py
@@ -74,7 +74,7 @@ class SearchService:
 
         # Fetch the provided URL as the system actor to retrieve the AP JSON
         try:
-            response = SystemActor().signed_request(
+            response = (self.identity or SystemActor()).signed_request(
                 method="get",
                 uri=self.query,
             )
@@ -103,7 +103,9 @@ class SearchService:
             # Try and retrieve the post by URI
             # (we do not trust the JSON we just got - fetch from source!)
             try:
-                return Post.by_object_uri(document["id"], fetch=True)
+                return Post.by_object_uri(
+                    document["id"], fetch=True, fetch_as=self.identity
+                )
             except Post.DoesNotExist:
                 return None
 


### PR DESCRIPTION
current implementation always use system actor which will not be able fetch a follower-only status, this pr fixes it. 