### PR TITLE
improve oauth compatibility

### DIFF
--- a/templates/api/oauth_authorize.html
+++ b/templates/api/oauth_authorize.html
@@ -32,7 +32,7 @@
                     {% if "push" in scope %}<li>Receive push notifications</li>{% endif %}
                 </ul>
                 <input type="hidden" name="client_id" value="{{ application.client_id }}">
-                <input type="hidden" name="state" value="{{ state }}">
+                <input type="hidden" name="state" value="{{ state|default:'' }}">
                 <input type="hidden" name="redirect_uri" value="{{ redirect_uri }}">
                 <input type="hidden" name="scope" value="{{ scope }}">
             </fieldset>


### PR DESCRIPTION
current oauth may pass `state=None` as additional parameter in redirect back to client, which cause problem for some picky client. this pr fixes it. 